### PR TITLE
Update urls in labs to comply with decorator

### DIFF
--- a/naiserator-labs.yaml
+++ b/naiserator-labs.yaml
@@ -42,8 +42,6 @@ spec:
   ingresses:
     - "https://dialogmoter.labs.nais.io/syk/dialogmoter"
   env:
-    - name: DECORATOR_URL
-      value: https://dekoratoren.nav.no
     - name: DECORATOR_ENV
       value: "prod"
     - name: LOGINSERVICE_URL
@@ -61,9 +59,9 @@ spec:
     - name: ENVIRONMENT
       value: "test"
     - name: DINE_SYKMELDTE_ROOT
-      value: https://sykefravaerarbeidsgiver.labs.nais.io/
+      value: https://www.nav.no/sykefravaerarbeidsgiver
     - name: DITT_SYKEFRAVAER_ROOT
-      value: https://sykefravaer.labs.nais.io/syk/sykefravaer
+      value: https://www.nav.no/syk/sykefravaer
     - name: BASE_PATH
       value: /syk/dialogmoter
   accessPolicy:


### PR DESCRIPTION
Dekoratøren støtter ikke domener utenfor `nav.no`

https://dialogmoter.labs.nais.io/syk/dialogmoter/sykmeldt (overskrevet av en nyere deploy per nå)