### PR TITLE
Use error type as message while logging error instead of generic string

### DIFF
--- a/src/server/utils/ncOptions.ts
+++ b/src/server/utils/ncOptions.ts
@@ -13,7 +13,10 @@ export const ncOptions: Options<NextApiRequest, NextApiResponse> = {
     req: NextApiRequest,
     res: NextApiResponse
   ) => {
-    serverLogger.error(err, "api request failed");
+    serverLogger.error(
+      err,
+      err.error.type ? err.error.type : "api request failed"
+    );
 
     if (err.error) {
       switch (err.error.type) {


### PR DESCRIPTION
Det er noe vanskelig å vurdere om feilen er noe man bør se på i Kibana, da hver feilmelding må åpnes for å se årsak. 
Bruker error type i stedet for mer oversiktelig logger.

![image](https://user-images.githubusercontent.com/4580431/173377817-a644ef1c-e156-4f81-b5a9-1f97dd0113b5.png)
