### PR TITLE
Legg til ekspertbistand som standardtekst-valg i referatet

### DIFF
--- a/src/common/constants/InfoUrls.ts
+++ b/src/common/constants/InfoUrls.ts
@@ -52,6 +52,11 @@ export const infoUrls: Record<DocumentComponentKey, InfoUrl | undefined> = {
     text: "Les mer om arbeidsrettet rehabilitering",
     url: "https://www.nav.no/arbeidsrettet-rehabilitering",
   },
+  EKSPERTBISTAND: {
+    key: "EKSPERTBISTAND",
+    text: "Les mer om tilskudd til ekspertbistand",
+    url: "https://www.nav.no/ekspertbistand",
+  },
   IKKE_BEHOV: undefined,
   OKONOMISK_STOTTE: undefined,
   UNKNOWN: undefined,

--- a/src/server/service/schema/brevSchema.ts
+++ b/src/server/service/schema/brevSchema.ts
@@ -50,6 +50,7 @@ const documentComponentKey = union([
   literal("MIDLERTIDIG_LONNSTILSKUDD"),
   literal("OKONOMISK_STOTTE"),
   literal("INGEN_RETTIGHETER"),
+  literal("EKSPERTBISTAND"),
 ]);
 
 const documentComponentKeyWithUnknown = union([


### PR DESCRIPTION
Det er behov for mulighet til å krysse av for standardtekst om ekspertbistand i referatet. Ref: https://trello.com/c/NWJ9Rbji/2069-legge-til-informasjon-om-ekspertbistand-som-avhukingsvalg-i-referatl%C3%B8sningen