### PR TITLE
Refactor names for MotebehovStatus

### DIFF
--- a/src/server/data/arbeidsgiver/fetchConcurrentDataAG.ts
+++ b/src/server/data/arbeidsgiver/fetchConcurrentDataAG.ts
@@ -9,7 +9,7 @@ import {
 } from "@/server/auth/tokenx";
 import { isMockBackend } from "@/server/utils/serverEnv";
 import { NextApiRequest } from "next";
-import { MotebehovDTO } from "@/server/service/schema/motebehovSchema";
+import { MotebehovStatusDTO } from "@/server/service/schema/motebehovSchema";
 import { Brev } from "../../../types/shared/brev";
 
 export const fetchConcurrentDataAG = async (
@@ -18,7 +18,7 @@ export const fetchConcurrentDataAG = async (
   orgnummer: string
 ): Promise<
   | {
-      motebehov: MotebehovDTO;
+      motebehov: MotebehovStatusDTO;
       brevArray: Brev[];
     }
   | undefined

--- a/src/server/data/common/mapDialogmoteData.ts
+++ b/src/server/data/common/mapDialogmoteData.ts
@@ -1,12 +1,12 @@
 import { mapReferater } from "@/server/data/common/mapReferater";
 import { mapMotebehov } from "@/server/data/common/mapMotebehov";
 import { SykmeldtDTO } from "@/server/service/schema/sykmeldtSchema";
-import { MotebehovDTO } from "@/server/service/schema/motebehovSchema";
+import { MotebehovStatusDTO } from "@/server/service/schema/motebehovSchema";
 import { BrevDTO } from "@/server/service/schema/brevSchema";
 import { DialogmoteData } from "types/shared/dialogmote";
 
 export const mapDialogmoteData = (
-  motebehov: MotebehovDTO,
+  motebehovStatus: MotebehovStatusDTO,
   brevArray?: BrevDTO[],
   sykmeldt?: SykmeldtDTO
 ): DialogmoteData => {
@@ -24,7 +24,7 @@ export const mapDialogmoteData = (
     latestBrev?.brevType === "NYTT_TID_STED";
 
   return {
-    motebehov: mapMotebehov(motebehov, isLatestBrevOngoingMoteinnkalling),
+    motebehov: mapMotebehov(motebehovStatus, isLatestBrevOngoingMoteinnkalling),
     moteinnkalling: !isLastestBrevReferat ? latestBrev : undefined,
     referater: mapReferater(brevArraySorted),
     sykmeldt: sykmeldt,

--- a/src/server/data/common/mapMotebehov.ts
+++ b/src/server/data/common/mapMotebehov.ts
@@ -1,6 +1,6 @@
 import {
   MotebehovDataDTO,
-  MotebehovDTO,
+  MotebehovStatusDTO,
 } from "@/server/service/schema/motebehovSchema";
 import { Motebehov, MotebehovSvar } from "types/shared/motebehov";
 
@@ -18,7 +18,7 @@ const mapMotebehovSvar = (
 };
 
 export const mapMotebehov = (
-  motebehovStatus: MotebehovDTO,
+  motebehovStatus: MotebehovStatusDTO,
   isLatestBrevOngoingMoteinnkalling: boolean
 ): Motebehov | undefined => {
   const displayMotebehov =

--- a/src/server/data/common/mapMotebehov.ts
+++ b/src/server/data/common/mapMotebehov.ts
@@ -24,7 +24,7 @@ export const mapMotebehov = (
   const displayMotebehov =
     motebehovStatus.visMotebehov && !isLatestBrevOngoingMoteinnkalling;
 
-  if (displayMotebehov && motebehovStatus.skjemaType) {
+  if (displayMotebehov) {
     return {
       skjemaType: motebehovStatus.skjemaType,
       svar: mapMotebehovSvar(motebehovStatus.motebehovWithFormValues),

--- a/src/server/data/mock/builders/motebehovBuilder.ts
+++ b/src/server/data/mock/builders/motebehovBuilder.ts
@@ -1,11 +1,11 @@
 import {
   MotebehovDataDTO,
-  MotebehovDTO,
+  MotebehovStatusDTO,
   MotebehovSkjemaTypeDTO,
 } from "@/server/service/schema/motebehovSchema";
 
 export class MotebehovBuilder {
-  private readonly motebehov: MotebehovDTO;
+  private readonly motebehov: MotebehovStatusDTO;
 
   constructor() {
     this.motebehov = {
@@ -30,7 +30,7 @@ export class MotebehovBuilder {
     return this;
   }
 
-  build(): MotebehovDTO {
+  build(): MotebehovStatusDTO {
     return this.motebehov;
   }
 }

--- a/src/server/data/mock/builders/testScenarioBuilder.ts
+++ b/src/server/data/mock/builders/testScenarioBuilder.ts
@@ -1,4 +1,4 @@
-import { MotebehovDTO } from "@/server/service/schema/motebehovSchema";
+import { MotebehovStatusDTO } from "@/server/service/schema/motebehovSchema";
 import { Brev } from "types/shared/brev";
 import { MockSetup, TestScenario } from "@/server/data/mock/getMockDb";
 
@@ -36,7 +36,7 @@ export class TestScenarioBuilder {
     return this;
   }
 
-  withMotebehov(motebehov: MotebehovDTO) {
+  withMotebehov(motebehov: MotebehovStatusDTO) {
     this.mockData.motebehov = motebehov;
     return this;
   }

--- a/src/server/data/mock/getMockDb.ts
+++ b/src/server/data/mock/getMockDb.ts
@@ -3,7 +3,7 @@ import { handleQueryParamError } from "../../utils/errors";
 import { NextApiRequest } from "next";
 import { TEST_SESSION_ID } from "@/common/api/axios/axios";
 import { Brev } from "../../../types/shared/brev";
-import { MotebehovDTO } from "@/server/service/schema/motebehovSchema";
+import { MotebehovStatusDTO } from "@/server/service/schema/motebehovSchema";
 import { SykmeldtDTO } from "@/server/service/schema/sykmeldtSchema";
 
 export type TestScenario =
@@ -16,7 +16,7 @@ export type TestScenario =
 export interface MockSetup {
   sykmeldt?: SykmeldtDTO; //For arbeidsgiver
   brev: Brev[];
-  motebehov: MotebehovDTO;
+  motebehov: MotebehovStatusDTO;
   activeTestScenario: TestScenario;
 }
 

--- a/src/server/data/sykmeldt/fetchConcurrentDataSM.ts
+++ b/src/server/data/sykmeldt/fetchConcurrentDataSM.ts
@@ -8,14 +8,14 @@ import {
 import getMockDb from "@/server/data/mock/getMockDb";
 import { NextApiRequest } from "next";
 import { isMockBackend } from "@/server/utils/serverEnv";
-import { MotebehovDTO } from "@/server/service/schema/motebehovSchema";
+import { MotebehovStatusDTO } from "@/server/service/schema/motebehovSchema";
 import { Brev } from "../../../types/shared/brev";
 
 export const fetchConcurrentDataSM = async (
   req: NextApiRequest
 ): Promise<
   | {
-      motebehov: MotebehovDTO;
+      motebehov: MotebehovStatusDTO;
       brevArray: Brev[];
     }
   | undefined

--- a/src/server/data/types/next/NextApiResponseAG.ts
+++ b/src/server/data/types/next/NextApiResponseAG.ts
@@ -1,12 +1,12 @@
 import { NextApiResponse } from "next";
 import { SykmeldtDTO } from "@/server/service/schema/sykmeldtSchema";
-import { MotebehovDTO } from "@/server/service/schema/motebehovSchema";
+import { MotebehovStatusDTO } from "@/server/service/schema/motebehovSchema";
 import { BrevDTO } from "@/server/service/schema/brevSchema";
 import { DialogmoteData } from "types/shared/dialogmote";
 
 export interface NextApiResponseAG extends NextApiResponse {
   sykmeldt: SykmeldtDTO;
-  motebehov: MotebehovDTO;
+  motebehov: MotebehovStatusDTO;
   brevArray: BrevDTO[];
   dialogmoteData: DialogmoteData;
 }

--- a/src/server/data/types/next/NextApiResponseSM.ts
+++ b/src/server/data/types/next/NextApiResponseSM.ts
@@ -1,10 +1,10 @@
 import { NextApiResponse } from "next";
-import { MotebehovDTO } from "@/server/service/schema/motebehovSchema";
+import { MotebehovStatusDTO } from "@/server/service/schema/motebehovSchema";
 import { BrevDTO } from "@/server/service/schema/brevSchema";
 import { DialogmoteData } from "types/shared/dialogmote";
 
 export interface NextApiResponseSM extends NextApiResponse {
-  motebehov: MotebehovDTO;
+  motebehov: MotebehovStatusDTO;
   brevArray: BrevDTO[];
   dialogmoteData: DialogmoteData;
 }

--- a/src/server/service/schema/motebehovSchema.ts
+++ b/src/server/service/schema/motebehovSchema.ts
@@ -31,6 +31,6 @@ export const motebehovStatusSchema = object({
   motebehovWithFormValues: motebehovWithFormValues.nullable(),
 });
 
-export type MotebehovDTO = z.infer<typeof motebehovStatusSchema>;
+export type MotebehovStatusDTO = z.infer<typeof motebehovStatusSchema>;
 export type MotebehovDataDTO = z.infer<typeof motebehovWithFormValues>;
 export type MotebehovSkjemaTypeDTO = z.infer<typeof skjemaType>;


### PR DESCRIPTION
Rename types and fields for MotebehovStatus from Motebehov to MotebehovStatus to make code more clear.