### PR TITLE
Rename motebehovStatus motebehov field

### DIFF
--- a/src/pages/api/arbeidsgiver/motebehov/index.api.ts
+++ b/src/pages/api/arbeidsgiver/motebehov/index.api.ts
@@ -21,7 +21,7 @@ const handler = async (
 
   if (isMockBackend) {
     const data = getMockDb(req);
-    getMockDb(req).motebehov.motebehovWithFormValues = {
+    getMockDb(req).motebehov.motebehov = {
       id: uuidv4(),
       opprettetDato: new Date().toISOString(),
       aktorId: "12345",

--- a/src/pages/api/sykmeldt/motebehov/index.api.ts
+++ b/src/pages/api/sykmeldt/motebehov/index.api.ts
@@ -21,7 +21,7 @@ const handler = async (
 
   if (isMockBackend) {
     const data = getMockDb(req);
-    getMockDb(req).motebehov.motebehovWithFormValues = {
+    getMockDb(req).motebehov.motebehov = {
       id: uuidv4(),
       opprettetDato: new Date().toISOString(),
       aktorId: "12345",

--- a/src/server/data/common/__tests__/mapDialogmoteData.test.ts
+++ b/src/server/data/common/__tests__/mapDialogmoteData.test.ts
@@ -26,7 +26,7 @@ describe("mapDialogmoteData", () => {
         {
           visMotebehov: false,
           skjemaType: "MELD_BEHOV",
-          motebehovWithFormValues: null,
+          motebehov: null,
         },
         [moteInnkalling, endretReferat]
       );
@@ -48,7 +48,7 @@ describe("mapDialogmoteData", () => {
         {
           visMotebehov: false,
           skjemaType: "MELD_BEHOV",
-          motebehovWithFormValues: null,
+          motebehov: null,
         },
         [moteInnkalling, referat]
       );
@@ -69,7 +69,7 @@ describe("mapDialogmoteData", () => {
         {
           visMotebehov: false,
           skjemaType: "MELD_BEHOV",
-          motebehovWithFormValues: null,
+          motebehov: null,
         },
         [moteInnkalling, referat]
       );
@@ -94,7 +94,7 @@ describe("mapDialogmoteData", () => {
         {
           visMotebehov: false,
           skjemaType: "MELD_BEHOV",
-          motebehovWithFormValues: null,
+          motebehov: null,
         },
         [referat, moteInnkalling, moteEndret]
       );
@@ -119,7 +119,7 @@ describe("mapDialogmoteData", () => {
         {
           visMotebehov: false,
           skjemaType: "MELD_BEHOV",
-          motebehovWithFormValues: null,
+          motebehov: null,
         },
         [referat, moteInnkalling, moteAvlyst]
       );

--- a/src/server/data/common/mapMotebehov.ts
+++ b/src/server/data/common/mapMotebehov.ts
@@ -27,7 +27,7 @@ export const mapMotebehov = (
   if (displayMotebehov) {
     return {
       skjemaType: motebehovStatus.skjemaType,
-      svar: mapMotebehovSvar(motebehovStatus.motebehovWithFormValues),
+      svar: mapMotebehovSvar(motebehovStatus.motebehov),
     };
   }
 

--- a/src/server/data/mock/builders/motebehovBuilder.ts
+++ b/src/server/data/mock/builders/motebehovBuilder.ts
@@ -11,7 +11,7 @@ export class MotebehovBuilder {
     this.motebehov = {
       visMotebehov: false,
       skjemaType: "MELD_BEHOV",
-      motebehovWithFormValues: null,
+      motebehov: null,
     };
   }
 
@@ -21,7 +21,7 @@ export class MotebehovBuilder {
   }
 
   withMotebehov(motebehov: MotebehovDataDTO): MotebehovBuilder {
-    this.motebehov.motebehovWithFormValues = motebehov;
+    this.motebehov.motebehov = motebehov;
     return this;
   }
 

--- a/src/server/data/mock/builders/testScenarioBuilder.ts
+++ b/src/server/data/mock/builders/testScenarioBuilder.ts
@@ -12,7 +12,7 @@ export class TestScenarioBuilder {
       motebehov: {
         visMotebehov: false,
         skjemaType: "MELD_BEHOV",
-        motebehovWithFormValues: null,
+        motebehov: null,
       },
       activeTestScenario: "MELD_BEHOV",
     };

--- a/src/server/service/schema/motebehovSchema.ts
+++ b/src/server/service/schema/motebehovSchema.ts
@@ -28,7 +28,7 @@ const motebehovWithFormValues = object({
 export const motebehovStatusSchema = object({
   visMotebehov: boolean(),
   skjemaType: skjemaType,
-  motebehovWithFormValues: motebehovWithFormValues.nullable(),
+  motebehov: motebehovWithFormValues.nullable(),
 });
 
 export type MotebehovStatusDTO = z.infer<typeof motebehovStatusSchema>;


### PR DESCRIPTION
After adding "copy" of the field with this name to DTO in backend.
To simplify the field names in backend API.