### PR TITLE
docs(readme): improve project overview and API documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,10 +12,13 @@ Frontend for dialogmøter på `nav.no`. Appen viser innhold for både sykmeldte 
 
 ## Miljøer
 
-- [🚀 Produksjon](https://www.nav.no/syk/dialogmoter)
-- [🛠️ Utvikling](https://www.ekstern.dev.nav.no/syk/dialogmoter)
-- [🎬 Demo - arbeidstaker](https://demo.ekstern.dev.nav.no/syk/dialogmoter/sykmeldt)
-- [🎬 Demo - arbeidsgiver](https://demo.ekstern.dev.nav.no/syk/dialogmoter/arbeidsgiver/1)
+[🚀 Produksjon](https://www.nav.no/syk/dialogmoter)
+
+[🛠️ Utvikling](https://www.ekstern.dev.nav.no/syk/dialogmoter)
+
+[🎬 Demo - arbeidstaker](https://demo.ekstern.dev.nav.no/syk/dialogmoter/sykmeldt)
+
+[🎬 Demo - arbeidsgiver](https://demo.ekstern.dev.nav.no/syk/dialogmoter/arbeidsgiver/1)
 
 ## Formålet med appen
 

--- a/README.md
+++ b/README.md
@@ -1,42 +1,113 @@
-This is a [Next.js](https://nextjs.org/) project bootstrapped with [`create-next-app`](https://github.com/vercel/next.js/tree/canary/packages/create-next-app).
+# Dialogmøter for sykmeldte og arbeidsgivere
 
-## Getting Started
+[![CI](https://github.com/navikt/dialogmote-frontend/actions/workflows/build-and-deploy.yaml/badge.svg)](https://github.com/navikt/dialogmote-frontend/actions/workflows/build-and-deploy.yaml)
+![Next.js](https://img.shields.io/badge/Next.js-16-000000?logo=nextdotjs)
+![React](https://img.shields.io/badge/React-19-149ECA?logo=react)
+![TypeScript](https://img.shields.io/badge/TypeScript-5-3178C6?logo=typescript&logoColor=white)
+![pnpm](https://img.shields.io/badge/pnpm-10-F69220?logo=pnpm&logoColor=white)
 
-### Installing dependencies
-This project uses modules from GitHub Package Repository and requires a PAT token in order to install the dependencies.
+Frontend for dialogmøter på `nav.no`. Appen viser innhold for både sykmeldte og arbeidsgivere under `/syk/dialogmoter`, og henter data via egne Next.js API-ruter som snakker med backend-tjenester i NAV.
 
-Go to [https://github.com/settings/tokens](https://github.com/settings/tokens) and create a PAT token with the `package:read` permission.  
+## Formål
 
-Export an environment variable named `NPM_AUTH_TOKEN` using `export NPM_AUTH_TOKEN=<PAT>`. 
+Repoet inneholder en Next.js-app for:
 
-### Start developing
-First, run the development server:
+- sykmeldt-flaten på `/syk/dialogmoter`
+- arbeidsgiver-flaten på `/syk/dialogmoter/arbeidsgiver/[narmestelederid]`
+- visning og innsending av motebehov
+- visning av møteinnkallinger og referater
 
-```bash
-npm run dev
-# or
-yarn dev
+## Arkitektur
+
+```mermaid
+flowchart LR
+  U[Bruker] --> A[dialogmote-frontend<br/>Next.js]
+  A -->|ID-porten| B[Next.js API-ruter]
+  B -->|TokenX| C[isdialogmote]
+  B -->|TokenX| D[syfomotebehov]
+  B -->|TokenX| E[dinesykmeldte-backend]
+  B -->|TokenX| F[oppfolgingsplan-backend]
 ```
 
-Open [http://localhost:3000](http://localhost:3000) with your browser to see the result.
+Appen bruker ID-porten-sidecar i NAIS og gjør TokenX on-behalf-of-utveksling mot interne tjenester.
 
-You can start editing the page by modifying `pages/index.tsx`. The page auto-updates as you edit the file.
+## Miljøer
 
-[API routes](https://nextjs.org/docs/api-routes/introduction) can be accessed on [http://localhost:3000/api/hello](http://localhost:3000/api/hello). This endpoint can be edited in `pages/api/hello.ts`.
+- Prod: https://www.nav.no/syk/dialogmoter
+- Dev: https://www.ekstern.dev.nav.no/syk/dialogmoter
 
-The `pages/api` directory is mapped to `/api/*`. Files in this directory are treated as [API routes](https://nextjs.org/docs/api-routes/introduction) instead of React pages.
+Repoet har også et demo-manifest for branchdeploy med mock-backend.
 
-## Learn More
+## Backend og integrasjoner
 
-To learn more about Next.js, take a look at the following resources:
+Frontendens API-ruter ligger under `src/pages/api` og bruker disse tjenestene:
 
-- [Next.js Documentation](https://nextjs.org/docs) - learn about Next.js features and API.
-- [Learn Next.js](https://nextjs.org/learn) - an interactive Next.js tutorial.
+- `isdialogmote` for brev, møteinnkallinger og referater
+- `syfomotebehov` for motebehov
+- `dinesykmeldte-backend` for oppslag av sykmeldt i arbeidsgiverflyten
+- `oppfolgingsplan-backend` for arbeidsgiverrelaterte oppslag
 
-You can check out [the Next.js GitHub repository](https://github.com/vercel/next.js/) - your feedback and contributions are welcome!
+I tillegg brukes:
 
-## Deploy on Vercel
+- NAV dekoratøren
+- NAV CDN for opplasting av sjelden endrede filer i `public/`
+- Grafana Faro for frontend-telemetri
 
-The easiest way to deploy your Next.js app is to use the [Vercel Platform](https://vercel.com/new?utm_medium=default-template&filter=next.js&utm_source=create-next-app&utm_campaign=create-next-app-readme) from the creators of Next.js.
+## Utviklerverktøy
 
-Check out our [Next.js deployment documentation](https://nextjs.org/docs/deployment) for more details.
+Repoet har `.mise.toml` med:
+
+- Node.js 24
+- pnpm 10
+
+Nyttige kommandoer med mise:
+
+```bash
+mise run install
+mise run dev
+mise run test
+mise run build
+mise run verify
+```
+
+## Utvikling
+
+### Installer avhengigheter
+
+Repoet bruker GitHub Package Registry for `@navikt`-pakker og krever en PAT med `package:read`.
+
+1. Opprett token på https://github.com/settings/tokens
+2. Eksporter token:
+
+```bash
+export NPM_AUTH_TOKEN=<PAT>
+```
+
+3. Installer avhengigheter:
+
+```bash
+pnpm install
+```
+
+### Start appen lokalt
+
+```bash
+pnpm run dev
+```
+
+Appen starter på http://localhost:3000 med base path `/syk/dialogmoter`.
+
+### Nyttige kommandoer
+
+```bash
+pnpm run check
+pnpm run test
+pnpm run build
+```
+
+## For NAV-ansatte
+
+- Team: `team-esyfo`
+- Appnavn i NAIS: `dialogmote-frontend`
+- Deploy skjer via workflowen `Build & Deploy`
+- Offentlige assets lastes opp via workflowen `Upload rarely changed public files to NAV CDN`

--- a/README.md
+++ b/README.md
@@ -16,10 +16,18 @@ Frontend for dialogmøter på `nav.no`. Appen viser innhold for både sykmeldte 
 
 ## Formålet med appen
 
-- sykmeldt-flaten på `/syk/dialogmoter`
-- arbeidsgiver-flaten på `/syk/dialogmoter/arbeidsgiver/[narmestelederid]`
-- visning og innsending av møtebehov
-- visning av møteinnkallinger og referater
+Appen håndterer dialogmøter mellom sykmeldte, arbeidsgivere og NAV som del av sykefraværsoppfølgingen. Den har to brukerflater:
+
+### Sykmeldt (`/syk/dialogmoter`)
+
+- **Møtebehov** — melde behov for dialogmøte og svare på forespørsler fra arbeidsgiver
+- **Møteinnkalling** — se innkalling til dialogmøte fra NAV
+- **Referat** — lese referater fra gjennomførte dialogmøter
+
+### Arbeidsgiver (`/syk/dialogmoter/arbeidsgiver/[narmestelederid]`)
+
+- **Møtebehov** — melde behov for dialogmøte på vegne av virksomheten og svare på forespørsler
+- **Brev** — se innkallinger og referater knyttet til den sykmeldte
 
 ## Backend og integrasjoner
 

--- a/README.md
+++ b/README.md
@@ -14,7 +14,9 @@ Frontend for dialogmøter på `nav.no`. Appen viser innhold for både sykmeldte 
 
 [🚀 Produksjon](https://www.nav.no/syk/dialogmoter)
 
-[🛠️ Utvikling](https://www.ekstern.dev.nav.no/syk/dialogmoter)
+[🛠️ Utvikling - arbeidstaker](https://www.ekstern.dev.nav.no/syk/dialogmoter/sykmeldt)
+
+[🛠️ Utvikling - arbeidsgiver](https://www.ekstern.dev.nav.no/syk/dialogmoter/arbeidsgiver/{id}), trenger en gyldig id
 
 [🎬 Demo - arbeidstaker](https://demo.ekstern.dev.nav.no/syk/dialogmoter/sykmeldt)
 

--- a/README.md
+++ b/README.md
@@ -58,9 +58,6 @@ I tillegg brukes:
 
 For å komme i gang med bygging og kjøring av appen, sjekk ut mise tasks.
 
-## For NAV-ansatte
+## For Nav-ansatte
 
-- Team: `team-esyfo`
-- Appnavn i NAIS: `dialogmote-frontend`
-- Deploy skjer via workflowen `Build & Deploy`
-- Offentlige assets lastes opp via workflowen `Upload rarely changed public files to NAV CDN`
+Interne henvendelser kan sendes via Slack i kanalen [#esyfo](https://nav-it.slack.com/archives/C012X796B4L).

--- a/README.md
+++ b/README.md
@@ -29,30 +29,31 @@ Appen håndterer dialogmøter mellom sykmeldte, arbeidsgivere og NAV som del av 
 - **Møtebehov** — melde behov for dialogmøte på vegne av virksomheten og svare på forespørsler
 - **Brev** — se innkallinger og referater knyttet til den sykmeldte
 
-## Backend og integrasjoner
+## Backend-API
 
-```mermaid
-flowchart LR
-  U[Bruker] --> A[dialogmote-frontend<br/>Next.js]
-  A -->|ID-porten| B[Next.js API-ruter]
-  B -->|TokenX| C[isdialogmote]
-  B -->|TokenX| D[syfomotebehov]
-  B -->|TokenX| E[dinesykmeldte-backend]
-  B -->|TokenX| F[oppfolgingsplan-backend]
-```
+Frontend-appen kommuniserer med flere backend-tjenester via Next.js API-ruter (`src/pages/api`). Alle kall bruker TokenX on-behalf-of-utveksling.
 
-Frontendens API-ruter ligger under `src/pages/api` og bruker disse tjenestene:
+### isdialogmote
 
-- `isdialogmote` for brev, møteinnkallinger og referater
-- `syfomotebehov` for møtebehov
-- `dinesykmeldte-backend` for oppslag av sykmeldt i arbeidsgiverflyten
-- `oppfolgingsplan-backend` for arbeidsgiverrelaterte oppslag
+| Metode | Endepunkt | Beskrivelse |
+|--------|-----------|-------------|
+| GET | `/api/v2/arbeidstaker/brev` | Hent brev (innkallinger/referater) for sykmeldt |
+| GET | `/api/v2/narmesteleder/brev` | Hent brev for arbeidsgiver |
 
-I tillegg brukes:
+### syfomotebehov
 
-- NAV dekoratøren
-- NAV CDN for opplasting av sjelden endrede filer i `public/`
-- Grafana Faro for frontend-telemetri
+| Metode | Endepunkt | Beskrivelse |
+|--------|-----------|-------------|
+| GET | `/syfomotebehov/api/v4/arbeidstaker/motebehov` | Hent møtebehov for sykmeldt |
+| GET | `/syfomotebehov/api/v4/motebehov?fnr=...&virksomhetsnummer=...` | Hent møtebehov for arbeidsgiver |
+| POST | `/syfomotebehov/api/v4/arbeidstaker/motebehov` | Meld/svar møtebehov som sykmeldt |
+| POST | `/syfomotebehov/api/v4/arbeidstaker/motebehov/ferdigstill` | Ferdigstill møtebehov |
+
+### dinesykmeldte-backend
+
+| Metode | Endepunkt | Beskrivelse |
+|--------|-----------|-------------|
+| GET | `/api/v2/dinesykmeldte/{narmestelederid}` | Hent sykmeldt-info i arbeidsgiverflyten |
 
 ## Utvikling (kjøre lokalt)
 

--- a/README.md
+++ b/README.md
@@ -1,8 +1,11 @@
 # Dialogmøter for sykmeldte og arbeidsgivere
 
+[![Build & Deploy](https://github.com/navikt/dialogmote-frontend/actions/workflows/build-and-deploy.yaml/badge.svg)](https://github.com/navikt/dialogmote-frontend/actions/workflows/build-and-deploy.yaml)
 ![Next.js](https://img.shields.io/badge/Next.js-16-000000?logo=nextdotjs)
 ![React](https://img.shields.io/badge/React-19-149ECA?logo=react)
 ![TypeScript](https://img.shields.io/badge/TypeScript-5-3178C6?logo=typescript&logoColor=white)
+![Biome](https://img.shields.io/badge/Biome-2-60A5FA?logo=biome&logoColor=white)
+![Vitest](https://img.shields.io/badge/Vitest-4-6E9F18?logo=vitest&logoColor=white)
 ![pnpm](https://img.shields.io/badge/pnpm-10-F69220?logo=pnpm&logoColor=white)
 
 Frontend for dialogmøter på `nav.no`. Appen viser innhold for både sykmeldte og arbeidsgivere under `/syk/dialogmoter`, og henter data via Next.js API-ruter som snakker med backend-tjenester.

--- a/README.md
+++ b/README.md
@@ -35,25 +35,31 @@ Frontend-appen kommuniserer med flere backend-tjenester via Next.js API-ruter (`
 
 ### isdialogmote
 
-| Metode | Endepunkt | Beskrivelse |
-|--------|-----------|-------------|
-| GET | `/api/v2/arbeidstaker/brev` | Hent brev (innkallinger/referater) for sykmeldt |
-| GET | `/api/v2/narmesteleder/brev` | Hent brev for arbeidsgiver |
+Brev, innkallinger og referater.
+
+```
+GET /api/v2/arbeidstaker/brev
+GET /api/v2/narmesteleder/brev
+```
 
 ### syfomotebehov
 
-| Metode | Endepunkt | Beskrivelse |
-|--------|-----------|-------------|
-| GET | `/syfomotebehov/api/v4/arbeidstaker/motebehov` | Hent møtebehov for sykmeldt |
-| GET | `/syfomotebehov/api/v4/motebehov?fnr=...&virksomhetsnummer=...` | Hent møtebehov for arbeidsgiver |
-| POST | `/syfomotebehov/api/v4/arbeidstaker/motebehov` | Meld/svar møtebehov som sykmeldt |
-| POST | `/syfomotebehov/api/v4/arbeidstaker/motebehov/ferdigstill` | Ferdigstill møtebehov |
+Møtebehov for sykmeldt og arbeidsgiver.
+
+```
+GET  /syfomotebehov/api/v4/arbeidstaker/motebehov
+GET  /syfomotebehov/api/v4/motebehov?fnr={fnr}&virksomhetsnummer={orgnummer}
+POST /syfomotebehov/api/v4/arbeidstaker/motebehov
+POST /syfomotebehov/api/v4/arbeidstaker/motebehov/ferdigstill
+```
 
 ### dinesykmeldte-backend
 
-| Metode | Endepunkt | Beskrivelse |
-|--------|-----------|-------------|
-| GET | `/api/v2/dinesykmeldte/{narmestelederid}` | Hent sykmeldt-info i arbeidsgiverflyten |
+Oppslag av sykmeldt i arbeidsgiverflyten.
+
+```
+GET /api/v2/dinesykmeldte/{narmestelederid}
+```
 
 ## Utvikling (kjøre lokalt)
 

--- a/README.md
+++ b/README.md
@@ -33,33 +33,27 @@ Appen håndterer dialogmøter mellom sykmeldte, arbeidsgivere og NAV som del av 
 
 Frontend-appen kommuniserer med flere backend-tjenester via Next.js API-ruter (`src/pages/api`). Alle kall bruker TokenX on-behalf-of-utveksling.
 
-### isdialogmote
+### [isdialogmote](https://github.com/navikt/isdialogmote)
 
 Brev, innkallinger og referater.
 
-```
-GET /api/v2/arbeidstaker/brev
-GET /api/v2/narmesteleder/brev
-```
+- **GET** `/api/v2/arbeidstaker/brev`
+- **GET** `/api/v2/narmesteleder/brev`
 
-### syfomotebehov
+### [syfomotebehov](https://github.com/navikt/syfomotebehov)
 
 Møtebehov for sykmeldt og arbeidsgiver.
 
-```
-GET  /syfomotebehov/api/v4/arbeidstaker/motebehov
-GET  /syfomotebehov/api/v4/motebehov?fnr={fnr}&virksomhetsnummer={orgnummer}
-POST /syfomotebehov/api/v4/arbeidstaker/motebehov
-POST /syfomotebehov/api/v4/arbeidstaker/motebehov/ferdigstill
-```
+- **GET** `/syfomotebehov/api/v4/arbeidstaker/motebehov`
+- **GET** `/syfomotebehov/api/v4/motebehov?fnr={fnr}&virksomhetsnummer={orgnummer}`
+- **POST** `/syfomotebehov/api/v4/arbeidstaker/motebehov`
+- **POST** `/syfomotebehov/api/v4/arbeidstaker/motebehov/ferdigstill`
 
-### dinesykmeldte-backend
+### [dinesykmeldte-backend](https://github.com/navikt/dinesykmeldte-backend)
 
 Oppslag av sykmeldt i arbeidsgiverflyten.
 
-```
-GET /api/v2/dinesykmeldte/{narmestelederid}
-```
+- **GET** `/api/v2/dinesykmeldte/{narmestelederid}`
 
 ## Utvikling (kjøre lokalt)
 

--- a/README.md
+++ b/README.md
@@ -1,23 +1,27 @@
 # Dialogmøter for sykmeldte og arbeidsgivere
 
-[![CI](https://github.com/navikt/dialogmote-frontend/actions/workflows/build-and-deploy.yaml/badge.svg)](https://github.com/navikt/dialogmote-frontend/actions/workflows/build-and-deploy.yaml)
 ![Next.js](https://img.shields.io/badge/Next.js-16-000000?logo=nextdotjs)
 ![React](https://img.shields.io/badge/React-19-149ECA?logo=react)
 ![TypeScript](https://img.shields.io/badge/TypeScript-5-3178C6?logo=typescript&logoColor=white)
 ![pnpm](https://img.shields.io/badge/pnpm-10-F69220?logo=pnpm&logoColor=white)
 
-Frontend for dialogmøter på `nav.no`. Appen viser innhold for både sykmeldte og arbeidsgivere under `/syk/dialogmoter`, og henter data via egne Next.js API-ruter som snakker med backend-tjenester i NAV.
+Frontend for dialogmøter på `nav.no`. Appen viser innhold for både sykmeldte og arbeidsgivere under `/syk/dialogmoter`, og henter data via Next.js API-ruter som snakker med backend-tjenester.
 
-## Formål
+## Miljøer
 
-Repoet inneholder en Next.js-app for:
+- [🚀 Produksjon](https://www.nav.no/syk/dialogmoter)
+- [🛠️ Utvikling](https://www.ekstern.dev.nav.no/syk/dialogmoter)
+- [🎬 Demo - arbeidstaker](https://demo.ekstern.dev.nav.no/syk/dialogmoter/sykmeldt)
+- [🎬 Demo - arbeidsgiver](https://demo.ekstern.dev.nav.no/syk/dialogmoter/arbeidsgiver/1)
+
+## Formålet med appen
 
 - sykmeldt-flaten på `/syk/dialogmoter`
 - arbeidsgiver-flaten på `/syk/dialogmoter/arbeidsgiver/[narmestelederid]`
-- visning og innsending av motebehov
+- visning og innsending av møtebehov
 - visning av møteinnkallinger og referater
 
-## Arkitektur
+## Backend og integrasjoner
 
 ```mermaid
 flowchart LR
@@ -29,21 +33,10 @@ flowchart LR
   B -->|TokenX| F[oppfolgingsplan-backend]
 ```
 
-Appen bruker ID-porten-sidecar i NAIS og gjør TokenX on-behalf-of-utveksling mot interne tjenester.
-
-## Miljøer
-
-- Prod: https://www.nav.no/syk/dialogmoter
-- Dev: https://www.ekstern.dev.nav.no/syk/dialogmoter
-
-Repoet har også et demo-manifest for branchdeploy med mock-backend.
-
-## Backend og integrasjoner
-
 Frontendens API-ruter ligger under `src/pages/api` og bruker disse tjenestene:
 
 - `isdialogmote` for brev, møteinnkallinger og referater
-- `syfomotebehov` for motebehov
+- `syfomotebehov` for møtebehov
 - `dinesykmeldte-backend` for oppslag av sykmeldt i arbeidsgiverflyten
 - `oppfolgingsplan-backend` for arbeidsgiverrelaterte oppslag
 
@@ -53,57 +46,9 @@ I tillegg brukes:
 - NAV CDN for opplasting av sjelden endrede filer i `public/`
 - Grafana Faro for frontend-telemetri
 
-## Utviklerverktøy
+## Utvikling (kjøre lokalt)
 
-Repoet har `.mise.toml` med:
-
-- Node.js 24
-- pnpm 10
-
-Nyttige kommandoer med mise:
-
-```bash
-mise run install
-mise run dev
-mise run test
-mise run build
-mise run verify
-```
-
-## Utvikling
-
-### Installer avhengigheter
-
-Repoet bruker GitHub Package Registry for `@navikt`-pakker og krever en PAT med `package:read`.
-
-1. Opprett token på https://github.com/settings/tokens
-2. Eksporter token:
-
-```bash
-export NPM_AUTH_TOKEN=<PAT>
-```
-
-3. Installer avhengigheter:
-
-```bash
-pnpm install
-```
-
-### Start appen lokalt
-
-```bash
-pnpm run dev
-```
-
-Appen starter på http://localhost:3000 med base path `/syk/dialogmoter`.
-
-### Nyttige kommandoer
-
-```bash
-pnpm run check
-pnpm run test
-pnpm run build
-```
+For å komme i gang med bygging og kjøring av appen, sjekk ut mise tasks.
 
 ## For NAV-ansatte
 


### PR DESCRIPTION
## Beskrivelse

Forbedrer README-en slik at repoet forklarer hva appen brukes til, hvilke miljøer som finnes, og hvilke backend-tjenester frontend-en snakker med.

## Endringer

- `README.md`: erstatter standard Next.js-tekst med prosjektspesifikk beskrivelse av dialogmote-frontend
- `README.md`: legger til badges for sentrale verktøy og synlige lenker til produksjon, utvikling og demo
- `README.md`: dokumenterer brukerflater, backend-API-er og kontaktpunkt for NAV-ansatte

## Issue

Ingen issue. Dette er en dokumentasjonsforbedring for å gjøre repoet enklere å forstå og vedlikeholde.

## Sjekkliste

- [ ] Koden kompilerer og linter uten feil
- [ ] Endringene er testet (manuelt eller automatisk)
- [ ] Ingen sensitiv data eksponert (tokens, credentials, PII)