### PR TITLE
fix(query): stopp retry når next backed returnerer 500 for alle 4xx og 5xx responsen

### DIFF
--- a/src/common/api/fetch/index.ts
+++ b/src/common/api/fetch/index.ts
@@ -1,5 +1,6 @@
 import { v4 as uuidv4 } from "uuid";
 import { isDemoOrLocal } from "@/common/publicEnv";
+import { HttpError } from "@/common/utils/errors/HttpError";
 import { logError } from "@/common/utils/logUtils";
 import { loginUser } from "@/common/utils/urlUtils";
 
@@ -103,7 +104,7 @@ const logAndThrowError = async (
   const message = `Fetch failed: method=${method} endpoint=${requestUrl} status=${response.status} ${response.statusText}${
     bodySnippet ? `: ${bodySnippet}` : ""
   }`;
-  const error = new Error(message);
+  const error = new HttpError(response.status, message);
   logError(error);
   throw error;
 };

--- a/src/common/api/queryRetry.test.ts
+++ b/src/common/api/queryRetry.test.ts
@@ -3,31 +3,15 @@ import { HttpError } from "@/common/utils/errors/HttpError";
 import { shouldRetryQuery } from "./queryRetry";
 
 describe("shouldRetryQuery", () => {
-  describe("when the error is a 4xx HttpError that is not retriable", () => {
-    it.each([400, 403, 404, 422])(
-      "should return false for status %s when failureCount is 0",
+  describe("when the error is an HttpError", () => {
+    it.each([400, 404, 408, 429, 500, 502, 503])(
+      "should return false for status %s when failureCount is less than 3",
       (statusCode) => {
-        expect(shouldRetryQuery(0, new HttpError(statusCode))).toBe(false);
+        expect(shouldRetryQuery(2, new HttpError(statusCode))).toBe(false);
       },
     );
 
-    it.each([400, 403, 404, 422])(
-      "should return false for status %s when failureCount is 3",
-      (statusCode) => {
-        expect(shouldRetryQuery(3, new HttpError(statusCode))).toBe(false);
-      },
-    );
-  });
-
-  describe("when the error is a retriable HttpError", () => {
-    it.each([408, 429, 500, 502, 503])(
-      "should return true for status %s when failureCount is less than 3",
-      (statusCode) => {
-        expect(shouldRetryQuery(2, new HttpError(statusCode))).toBe(true);
-      },
-    );
-
-    it.each([408, 429, 500, 502, 503])(
+    it.each([400, 404, 408, 429, 500, 502, 503])(
       "should return false for status %s when failureCount is 3 or more",
       (statusCode) => {
         expect(shouldRetryQuery(3, new HttpError(statusCode))).toBe(false);

--- a/src/common/api/queryRetry.test.ts
+++ b/src/common/api/queryRetry.test.ts
@@ -1,0 +1,56 @@
+import { describe, expect, it } from "vitest";
+import { HttpError } from "@/common/utils/errors/HttpError";
+import { shouldRetryQuery } from "./queryRetry";
+
+describe("shouldRetryQuery", () => {
+  describe("when the error is a 4xx HttpError that is not retriable", () => {
+    it.each([400, 403, 404, 422])(
+      "should return false for status %s when failureCount is 0",
+      (statusCode) => {
+        expect(shouldRetryQuery(0, new HttpError(statusCode))).toBe(false);
+      },
+    );
+
+    it.each([400, 403, 404, 422])(
+      "should return false for status %s when failureCount is 3",
+      (statusCode) => {
+        expect(shouldRetryQuery(3, new HttpError(statusCode))).toBe(false);
+      },
+    );
+  });
+
+  describe("when the error is a retriable HttpError", () => {
+    it.each([408, 429, 500, 502, 503])(
+      "should return true for status %s when failureCount is less than 3",
+      (statusCode) => {
+        expect(shouldRetryQuery(2, new HttpError(statusCode))).toBe(true);
+      },
+    );
+
+    it.each([408, 429, 500, 502, 503])(
+      "should return false for status %s when failureCount is 3 or more",
+      (statusCode) => {
+        expect(shouldRetryQuery(3, new HttpError(statusCode))).toBe(false);
+        expect(shouldRetryQuery(4, new HttpError(statusCode))).toBe(false);
+      },
+    );
+  });
+
+  describe("when the error is not an HttpError", () => {
+    it("should return true for a network error when failureCount is less than 3", () => {
+      expect(shouldRetryQuery(2, new Error("Network error"))).toBe(true);
+    });
+
+    it("should return false for a network error when failureCount is 3 or more", () => {
+      expect(shouldRetryQuery(3, new Error("Network error"))).toBe(false);
+    });
+
+    it("should return true for an unknown error when failureCount is less than 3", () => {
+      expect(shouldRetryQuery(2, "unknown error")).toBe(true);
+    });
+
+    it("should return false for an unknown error when failureCount is 3 or more", () => {
+      expect(shouldRetryQuery(3, "unknown error")).toBe(false);
+    });
+  });
+});

--- a/src/common/api/queryRetry.ts
+++ b/src/common/api/queryRetry.ts
@@ -4,13 +4,7 @@ export const shouldRetryQuery = (
   failureCount: number,
   error: unknown,
 ): boolean => {
-  if (
-    error instanceof HttpError &&
-    error.code >= 400 &&
-    error.code < 500 &&
-    error.code !== 408 &&
-    error.code !== 429
-  ) {
+  if (error instanceof HttpError) {
     return false;
   }
 

--- a/src/common/api/queryRetry.ts
+++ b/src/common/api/queryRetry.ts
@@ -1,0 +1,18 @@
+import { HttpError } from "@/common/utils/errors/HttpError";
+
+export const shouldRetryQuery = (
+  failureCount: number,
+  error: unknown,
+): boolean => {
+  if (
+    error instanceof HttpError &&
+    error.code >= 400 &&
+    error.code < 500 &&
+    error.code !== 408 &&
+    error.code !== 429
+  ) {
+    return false;
+  }
+
+  return failureCount < 3;
+};

--- a/src/pages/_app.page.tsx
+++ b/src/pages/_app.page.tsx
@@ -6,6 +6,7 @@ import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import { ReactQueryDevtools } from "@tanstack/react-query-devtools";
 import type { AppProps } from "next/app";
 import { useEffect } from "react";
+import { shouldRetryQuery } from "@/common/api/queryRetry";
 import { BreadcrumbsAppenderAG } from "@/common/breadcrumbs/BreadcrumbsAppenderAG";
 import { BreadcrumbsAppenderSM } from "@/common/breadcrumbs/BreadcrumbsAppenderSM";
 import { DMErrorBoundary } from "@/common/components/error/DMErrorBoundary";
@@ -36,6 +37,7 @@ const queryClient = new QueryClient({
     queries: {
       refetchOnWindowFocus: false,
       gcTime: minutesToMillis(60),
+      retry: shouldRetryQuery,
     },
   },
 });


### PR DESCRIPTION
## Beskrivelse

Stopper unødvendige React Query-retries for de fleste 4xx-feil. Vi retryer fortsatt 408 og 429 fordi nye forsøk kan lykkes, noe som reduserer støy i logger og ventetid for brukeren.

## Endringer

- `src/common/api/fetch/index.ts`: kaster nå `HttpError` med statuskode fra fetch
- `src/common/api/queryRetry.ts`: legger til `shouldRetryQuery` for retry-regler
- `src/common/api/queryRetry.test.ts`: legger til enhetstester for retry-logikken
- `src/pages/_app.page.tsx`: bruker `shouldRetryQuery` i `QueryClient`-konfigurasjonen

## Issue

Closes #1730

## Sjekkliste

- [x] Koden kompilerer og linter uten feil
- [x] Endringene er testet (manuelt eller automatisk)
- [x] Ingen sensitiv data eksponert (tokens, credentials, PII)