### PR TITLE
refactor(imports): bruk eksplisitte path-aliaser

### DIFF
--- a/src/common/api/queries/arbeidsgiver/dialogmoteDataQueryAG.ts
+++ b/src/common/api/queries/arbeidsgiver/dialogmoteDataQueryAG.ts
@@ -1,8 +1,8 @@
 import { useQuery } from "@tanstack/react-query";
-import type { DialogmoteData } from "types/shared/dialogmote";
 import { get } from "@/common/api/fetch";
 import { useApiBasePath } from "@/common/hooks/routeHooks";
 import { useNarmesteLederId } from "@/common/hooks/useNarmesteLederId";
+import type { DialogmoteData } from "@/types/shared/dialogmote";
 
 export const DIALOGMOTEDATA_AG = "dialogmotedata-arbeidsgiver";
 

--- a/src/common/api/queries/arbeidsgiver/motebehovQueriesAG.ts
+++ b/src/common/api/queries/arbeidsgiver/motebehovQueriesAG.ts
@@ -1,9 +1,9 @@
 import { useMutation } from "@tanstack/react-query";
 import { useRouter } from "next/router";
-import type { MotebehovSvarRequestAG } from "types/shared/motebehov";
 import { post } from "@/common/api/fetch";
 import { useApiBasePath, useLandingUrl } from "@/common/hooks/routeHooks";
 import { useNotifications } from "@/context/NotificationContext";
+import type { MotebehovSvarRequestAG } from "@/types/shared/motebehov";
 
 export const useSvarPaMotebehovAG = () => {
   const basepath = useApiBasePath();

--- a/src/common/api/queries/brevQueries.ts
+++ b/src/common/api/queries/brevQueries.ts
@@ -1,9 +1,9 @@
 import { useMutation, useQueryClient } from "@tanstack/react-query";
-import type { SvarRespons } from "types/shared/brev";
 import { post } from "@/common/api/fetch";
 import { DIALOGMOTEDATA_AG } from "@/common/api/queries/arbeidsgiver/dialogmoteDataQueryAG";
 import { DIALOGMOTEDATA_SM } from "@/common/api/queries/sykmeldt/dialogmoteDataQuerySM";
 import { useApiBasePath, useAudience } from "@/common/hooks/routeHooks";
+import type { SvarRespons } from "@/types/shared/brev";
 
 type SvarResponsRequest = Omit<SvarRespons, "svarTidspunkt">;
 

--- a/src/common/api/queries/sykmeldt/dialogmoteDataQuerySM.ts
+++ b/src/common/api/queries/sykmeldt/dialogmoteDataQuerySM.ts
@@ -1,7 +1,7 @@
 import { useQuery } from "@tanstack/react-query";
-import type { DialogmoteData } from "types/shared/dialogmote";
 import { get } from "@/common/api/fetch";
 import { useApiBasePath } from "@/common/hooks/routeHooks";
+import type { DialogmoteData } from "@/types/shared/dialogmote";
 
 export const DIALOGMOTEDATA_SM = "dialogmotedata-sykmeldt";
 

--- a/src/common/breadcrumbs/breadcrumbPaths.ts
+++ b/src/common/breadcrumbs/breadcrumbPaths.ts
@@ -3,7 +3,7 @@ import {
   dineSykemeldteRoot,
   dittSykefravarRoot,
   minSideRoot,
-} from "../publicEnv";
+} from "@/common/publicEnv";
 
 // Breadcrumbs for sykmeldt
 export function baseBreadcrumbSM() {

--- a/src/common/components/button/CancelButton.tsx
+++ b/src/common/components/button/CancelButton.tsx
@@ -5,7 +5,7 @@ import { useLandingUrl } from "@/common/hooks/routeHooks";
 const texts = {
   avbryt: "Avbryt",
 };
-
+//fix
 export const CancelButton = () => {
   const landingUrl = useLandingUrl();
 

--- a/src/common/components/button/CancelButton.tsx
+++ b/src/common/components/button/CancelButton.tsx
@@ -5,7 +5,6 @@ import { useLandingUrl } from "@/common/hooks/routeHooks";
 const texts = {
   avbryt: "Avbryt",
 };
-//fix
 export const CancelButton = () => {
   const landingUrl = useLandingUrl();
 

--- a/src/common/components/document/DocumentContainer.tsx
+++ b/src/common/components/document/DocumentContainer.tsx
@@ -1,9 +1,9 @@
 import { Box, Heading } from "@navikt/ds-react";
 import { type ReactNode, useEffect } from "react";
-import type { DocumentComponent } from "types/client/brev";
-import type { ReferatDocumentComponent } from "types/shared/brev";
 import { useMutateBrevLest } from "@/common/api/queries/brevQueries";
 import DocumentRenderer from "@/common/components/document/DocumentRenderer";
+import type { DocumentComponent } from "@/types/client/brev";
+import type { ReferatDocumentComponent } from "@/types/shared/brev";
 
 interface DocumentContainerProps {
   title: string;

--- a/src/common/components/document/DocumentRenderer.tsx
+++ b/src/common/components/document/DocumentRenderer.tsx
@@ -1,8 +1,8 @@
 import { BodyLong, Heading, Link } from "@navikt/ds-react";
-import type { DocumentComponent } from "types/client/brev";
-import type { ReferatDocumentComponent } from "types/shared/brev";
 import { Events } from "@/common/analytics/events";
 import { useAnalytics } from "@/common/hooks/useAnalytics";
+import type { DocumentComponent } from "@/types/client/brev";
+import type { ReferatDocumentComponent } from "@/types/shared/brev";
 
 interface Props {
   documentComponent: DocumentComponent | ReferatDocumentComponent;
@@ -90,9 +90,7 @@ const DocumentRenderer = ({ documentComponent }: Props) => {
             </Heading>
           )}
           {texts.map((text) => (
-            <BodyLong key={`paragraph-${text}-${title ?? ""}`}>
-              {text}
-            </BodyLong>
+            <BodyLong key={`paragraph-${text}-${title ?? ""}`}>{text}</BodyLong>
           ))}
         </>
       );

--- a/src/common/components/document/__tests__/DocumentContainer.test.tsx
+++ b/src/common/components/document/__tests__/DocumentContainer.test.tsx
@@ -2,8 +2,8 @@ import { waitFor } from "@testing-library/react";
 import { HttpResponse, http } from "msw";
 import mockRouter from "next-router-mock";
 import { beforeEach, describe, expect, it, vi } from "vitest";
-import { createDocumentComponent } from "../../../../mocks/data/factories/brev";
-import { testServer } from "../../../../mocks/testServer";
+import { createDocumentComponent } from "@/mocks/data/factories/brev";
+import { testServer } from "@/mocks/testServer";
 import { render, screen } from "../../../../test/testUtils";
 import DocumentContainer from "../DocumentContainer";
 

--- a/src/common/components/motebehov/MeldBehovForm.tsx
+++ b/src/common/components/motebehov/MeldBehovForm.tsx
@@ -1,6 +1,5 @@
 import { Checkbox, Textarea, TextField } from "@navikt/ds-react";
 import { Controller, useForm, useWatch } from "react-hook-form";
-import type { MotebehovSvarRequest } from "types/shared/motebehov";
 import { CancelButton } from "@/common/components/button/CancelButton";
 import { SubmitButton } from "@/common/components/button/SubmitButton";
 import { MotebehovErrorSummary } from "@/common/components/motebehov/MotebehovErrorSummary";
@@ -12,6 +11,7 @@ import type {
   FormSnapshotRequestDto,
   MotebehovFormIdentifier,
 } from "@/server/service/schema/formSnapshotSchema";
+import type { MotebehovSvarRequest } from "@/types/shared/motebehov";
 import { commonTextsForSvarAndMeld } from "./SvarBehovForm";
 
 const MAX_LENGTH_BEHOV_BEGRUNNELSE = 1000;

--- a/src/common/components/motebehov/MotebehovHarSvartPanel.tsx
+++ b/src/common/components/motebehov/MotebehovHarSvartPanel.tsx
@@ -1,12 +1,12 @@
 import { BodyLong } from "@navikt/ds-react";
 import { logger } from "@navikt/next-logger";
 import type { ReactNode } from "react";
+import Receipt from "@/common/components/motebehov/receipt/Receipt";
+import DialogmotePanel from "@/common/components/panel/DialogmotePanel";
 import type {
   MotebehovSkjemaType,
   MotebehovSvar,
-} from "types/shared/motebehov";
-import Receipt from "@/common/components/motebehov/receipt/Receipt";
-import DialogmotePanel from "@/common/components/panel/DialogmotePanel";
+} from "@/types/shared/motebehov";
 
 interface Props {
   motebehovSvar: MotebehovSvar;

--- a/src/common/components/motebehov/MotebehovSubmitButton.tsx
+++ b/src/common/components/motebehov/MotebehovSubmitButton.tsx
@@ -1,11 +1,11 @@
 import { Chat2Icon } from "@navikt/aksel-icons";
 import { LinkCard } from "@navikt/ds-react";
 import NextLink from "next/link";
-import type { MotebehovSkjemaType } from "types/shared/motebehov";
 import { Events } from "@/common/analytics/events";
 import CircledIcon from "@/common/components/icon/CircledIcon";
 import { useLandingUrl } from "@/common/hooks/routeHooks";
 import { useAnalytics } from "@/common/hooks/useAnalytics";
+import type { MotebehovSkjemaType } from "@/types/shared/motebehov";
 
 interface Props {
   skjemaType: MotebehovSkjemaType;

--- a/src/common/components/motebehov/panel/MotebehovPanelSM.tsx
+++ b/src/common/components/motebehov/panel/MotebehovPanelSM.tsx
@@ -2,7 +2,7 @@ import { BodyLong, Heading } from "@navikt/ds-react";
 import { MotebehovHarSvartPanel } from "@/common/components/motebehov/MotebehovHarSvartPanel";
 import { MotebehovSubmitButton } from "@/common/components/motebehov/MotebehovSubmitButton";
 import DialogmotePanel from "@/common/components/panel/DialogmotePanel";
-import type { Motebehov } from "../../../../types/shared/motebehov";
+import type { Motebehov } from "@/types/shared/motebehov";
 
 const HvaErEtDialogmoteSM = () => {
   return (

--- a/src/common/components/moteinnkalling/AvlystMoteinnkalling.tsx
+++ b/src/common/components/moteinnkalling/AvlystMoteinnkalling.tsx
@@ -1,5 +1,5 @@
-import type { Brev } from "types/shared/brev";
 import DocumentContainer from "@/common/components/document/DocumentContainer";
+import type { Brev } from "@/types/shared/brev";
 
 const texts = {
   titleAvlysning: "Avlysning av dialogmøte",

--- a/src/common/components/moteinnkalling/DittSvarPaInnkallelse.tsx
+++ b/src/common/components/moteinnkalling/DittSvarPaInnkallelse.tsx
@@ -1,7 +1,7 @@
 import { BodyLong, LocalAlert } from "@navikt/ds-react";
 import type { ReactElement } from "react";
-import type { SvarType } from "types/shared/brev";
 import { KontaktOssLink } from "@/common/components/kontaktoss/KontaktOssLink";
+import type { SvarType } from "@/types/shared/brev";
 
 const texts = {
   svartKommer: "Du har svart at du kommer til dette dialogmøtet.",

--- a/src/common/components/moteinnkalling/GiSvarPaInnkallelse.tsx
+++ b/src/common/components/moteinnkalling/GiSvarPaInnkallelse.tsx
@@ -13,12 +13,12 @@ import {
   useEffect,
   useState,
 } from "react";
-import type { SvarType } from "types/shared/brev";
 import { Events } from "@/common/analytics/events";
 import { useSvarPaInnkallelse } from "@/common/api/queries/brevQueries";
 import DialogmotePanel from "@/common/components/panel/DialogmotePanel";
 import { commonTexts } from "@/common/constants/commonTexts";
 import { useAnalytics } from "@/common/hooks/useAnalytics";
+import type { SvarType } from "@/types/shared/brev";
 
 const texts = {
   title: "Gi oss ditt svar",

--- a/src/common/components/moteinnkalling/MoteinnkallingContent.tsx
+++ b/src/common/components/moteinnkalling/MoteinnkallingContent.tsx
@@ -2,7 +2,7 @@ import { Skeleton } from "@navikt/ds-react";
 import { ErrorWithEscapeRoute } from "@/common/components/error/ErrorWithEscapeRoute";
 import { AvlystMoteinnkalling } from "@/common/components/moteinnkalling/AvlystMoteinnkalling";
 import { PaagaaendeMoteinnkalling } from "@/common/components/moteinnkalling/PaagaaendeMoteinnkalling";
-import type { Brev } from "../../../types/shared/brev";
+import type { Brev } from "@/types/shared/brev";
 
 interface Props {
   isLoading: boolean;

--- a/src/common/components/moteinnkalling/MoteinnkallingPanel.tsx
+++ b/src/common/components/moteinnkalling/MoteinnkallingPanel.tsx
@@ -1,11 +1,11 @@
 import { BodyShort, Button, LocalAlert } from "@navikt/ds-react";
 import NextLink from "next/link";
-import type { BrevType } from "types/client/brev";
-import type { Brev } from "types/shared/brev";
 import { Events } from "@/common/analytics/events";
 import DialogmotePanel from "@/common/components/panel/DialogmotePanel";
 import { useLandingUrl } from "@/common/hooks/routeHooks";
 import { useAnalytics } from "@/common/hooks/useAnalytics";
+import type { BrevType } from "@/types/client/brev";
+import type { Brev } from "@/types/shared/brev";
 import DittSvarPaInnkallelse from "./DittSvarPaInnkallelse";
 
 const getTexts = (brevType: BrevType) => {

--- a/src/common/components/moteinnkalling/PaagaaendeMoteinnkalling.tsx
+++ b/src/common/components/moteinnkalling/PaagaaendeMoteinnkalling.tsx
@@ -1,10 +1,10 @@
 import { GuidePanel, LocalAlert } from "@navikt/ds-react";
-import type { Brev } from "types/shared/brev";
 import DocumentContainer from "@/common/components/document/DocumentContainer";
 import DittSvarPaInnkallelse from "@/common/components/moteinnkalling/DittSvarPaInnkallelse";
 import GiSvarPaInnkallelse from "@/common/components/moteinnkalling/GiSvarPaInnkallelse";
 import VeilederInnkallelseContent from "@/common/components/moteinnkalling/VeilederInnkallelseContent";
 import { isDateInPast } from "@/common/utils/dateUtils";
+import type { Brev } from "@/types/shared/brev";
 
 interface Props {
   moteinnkalling: Brev;

--- a/src/common/components/page/ArbeidsgiverSide.tsx
+++ b/src/common/components/page/ArbeidsgiverSide.tsx
@@ -5,7 +5,7 @@ import { useDialogmoteDataAG } from "@/common/api/queries/arbeidsgiver/dialogmot
 import { PageHeading } from "@/common/components/header/PageHeading";
 import { ArbeidsgiverSideMenu } from "@/common/components/menu/ArbeidsgiverSideMenu";
 import { addSpaceAfterEverySixthCharacter } from "@/common/utils/stringUtils";
-import type { Sykmeldt } from "../../../types/shared/sykmeldt";
+import type { Sykmeldt } from "@/types/shared/sykmeldt";
 
 const getSykmeldtHeader = (sykmeldt?: Sykmeldt) => {
   if (sykmeldt?.navn && sykmeldt.fnr) {

--- a/src/common/components/personvern/PersonvernInfo.tsx
+++ b/src/common/components/personvern/PersonvernInfo.tsx
@@ -1,7 +1,7 @@
 import { BodyLong, Link } from "@navikt/ds-react";
 import { Events } from "@/common/analytics/events";
+import { PERSONVERN_URL } from "@/common/constants/staticUrls";
 import { useAnalytics } from "@/common/hooks/useAnalytics";
-import { PERSONVERN_URL } from "../../constants/staticUrls";
 
 const texts = {
   bottomText: "Vi bruker opplysningene også til å gjøre selve tjenesten bedre.",

--- a/src/common/components/referat/GamleReferat.tsx
+++ b/src/common/components/referat/GamleReferat.tsx
@@ -1,8 +1,8 @@
-import type { Referat } from "types/shared/brev";
 import { Events } from "@/common/analytics/events";
 import RouterLenke from "@/common/components/navigation/RouterLenke";
 import { useReferatPath } from "@/common/hooks/routeHooks";
 import { getLongDateFormat } from "@/common/utils/dateUtils";
+import type { Referat } from "@/types/shared/brev";
 
 const linkText = (moteDato: string) => {
   return `Referat fra møte ${moteDato}`;

--- a/src/common/components/referat/ReferatContent.tsx
+++ b/src/common/components/referat/ReferatContent.tsx
@@ -1,6 +1,5 @@
 import { Skeleton } from "@navikt/ds-react";
 import type { UseQueryResult } from "@tanstack/react-query";
-import type { DialogmoteData } from "types/shared/dialogmote";
 import { Events } from "@/common/analytics/events";
 import DownloadPdfButton from "@/common/components/button/DownloadPdfButton";
 import DocumentContainer from "@/common/components/document/DocumentContainer";
@@ -9,6 +8,7 @@ import UsefulLinks from "@/common/components/referat/UsefulLinks";
 import KontaktOssVeileder from "@/common/components/veileder/KontaktOssVeileder";
 import { usePdfPath } from "@/common/hooks/routeHooks";
 import { useBrevUuid } from "@/common/hooks/useBrevUuid";
+import type { DialogmoteData } from "@/types/shared/dialogmote";
 
 interface Props {
   dialogmoteData: UseQueryResult<DialogmoteData>;

--- a/src/common/components/referat/ReferaterPanel.tsx
+++ b/src/common/components/referat/ReferaterPanel.tsx
@@ -1,8 +1,8 @@
 import type { ReactNode } from "react";
-import type { Referat } from "types/shared/brev";
 import DialogmotePanel from "@/common/components/panel/DialogmotePanel";
 import GamleReferat from "@/common/components/referat/GamleReferat";
 import SisteReferat from "@/common/components/referat/SisteReferat";
+import type { Referat } from "@/types/shared/brev";
 
 const texts = {
   title: "Referat fra dialogmøte",

--- a/src/common/components/referat/SisteReferat.tsx
+++ b/src/common/components/referat/SisteReferat.tsx
@@ -1,10 +1,10 @@
 import { LinkCard } from "@navikt/ds-react";
 import NextLink from "next/link";
-import type { Referat } from "types/shared/brev";
 import { Events } from "@/common/analytics/events";
 import { useReferatPath } from "@/common/hooks/routeHooks";
 import { useAnalytics } from "@/common/hooks/useAnalytics";
 import { getLongDateFormat } from "@/common/utils/dateUtils";
+import type { Referat } from "@/types/shared/brev";
 
 const texts = {
   text: "Referatet oppsummerer det vi snakket om i dialogmøtet",

--- a/src/common/components/referat/UsefulLinks.tsx
+++ b/src/common/components/referat/UsefulLinks.tsx
@@ -1,8 +1,8 @@
 import { Heading, Link, LocalAlert } from "@navikt/ds-react";
-import type { InfoUrl } from "types/client/infoUrl";
-import type { Referat } from "types/shared/brev";
 import { Events } from "@/common/analytics/events";
 import { useAnalytics } from "@/common/hooks/useAnalytics";
+import type { InfoUrl } from "@/types/client/infoUrl";
+import type { Referat } from "@/types/shared/brev";
 
 const texts = {
   title: "Du kan finne mer informasjon på nav.no:",

--- a/src/common/components/testscenarioselector/TestScenarioSelector.tsx
+++ b/src/common/components/testscenarioselector/TestScenarioSelector.tsx
@@ -1,11 +1,11 @@
 import { Button, Heading, Modal, Radio, RadioGroup } from "@navikt/ds-react";
 import Image from "next/image";
 import { useState } from "react";
-import type { TestScenario } from "server/data/mock/getMockDb";
 import {
   useActiveTestScenario,
   useSetActiveTestScenario,
 } from "@/common/api/queries/testScenarioQueries";
+import type { TestScenario } from "@/server/data/mock/getMockDb";
 import SunImage from "../../images/sun.svg";
 import styles from "./testscenarioselector.module.css";
 

--- a/src/common/constants/InfoUrls.ts
+++ b/src/common/constants/InfoUrls.ts
@@ -1,5 +1,5 @@
-import type { DocumentComponentKey } from "types/client/brev";
-import type { InfoUrl } from "types/client/infoUrl";
+import type { DocumentComponentKey } from "@/types/client/brev";
+import type { InfoUrl } from "@/types/client/infoUrl";
 
 export const infoUrls: Record<DocumentComponentKey, InfoUrl | undefined> = {
   FRISKMELDING_ARBEIDSFORMIDLING: {

--- a/src/common/utils/arbeidsgiverSideMenu.ts
+++ b/src/common/utils/arbeidsgiverSideMenu.ts
@@ -1,9 +1,9 @@
 import { PersonIcon } from "@navikt/aksel-icons";
 import { addSpaceAfterEverySixthCharacter } from "@/common/utils/stringUtils";
-import type { DialogmoteData } from "../../types/shared/dialogmote";
+import type { DialogmoteData } from "@/types/shared/dialogmote";
 
 export const getAgSideMenuHeader = (dialogmoteData?: DialogmoteData) => {
-  if (!!dialogmoteData?.sykmeldt?.navn && !!dialogmoteData?.sykmeldt?.fnr) {
+  if (dialogmoteData?.sykmeldt?.navn && dialogmoteData?.sykmeldt?.fnr) {
     return {
       title: dialogmoteData?.sykmeldt?.navn,
       subtitle: `Fødselsnr: ${addSpaceAfterEverySixthCharacter(

--- a/src/mocks/data/factories/brev.ts
+++ b/src/mocks/data/factories/brev.ts
@@ -1,5 +1,5 @@
-import type { DocumentComponent } from "types/client/brev";
-import type { Brev } from "types/shared/brev";
+import type { DocumentComponent } from "@/types/client/brev";
+import type { Brev } from "@/types/shared/brev";
 
 export const createDocumentComponent = (
   props?: Partial<DocumentComponent>,

--- a/src/mocks/data/factories/dialogmote.ts
+++ b/src/mocks/data/factories/dialogmote.ts
@@ -1,4 +1,4 @@
-import type { DialogmoteData } from "../../../types/shared/dialogmote";
+import type { DialogmoteData } from "@/types/shared/dialogmote";
 import { sykmeldtFixture } from "../fixtures/sykmeldt";
 
 export const createDialogmoteSM = (

--- a/src/mocks/data/fixtures/sykmeldt.ts
+++ b/src/mocks/data/fixtures/sykmeldt.ts
@@ -1,4 +1,4 @@
-import type { Sykmeldt } from "../../../types/shared/sykmeldt";
+import type { Sykmeldt } from "@/types/shared/sykmeldt";
 
 export const sykmeldtFixture: Sykmeldt = {
   narmestelederId: "123",

--- a/src/pages/api/arbeidsgiver/brev/[uuid]/svar.api.ts
+++ b/src/pages/api/arbeidsgiver/brev/[uuid]/svar.api.ts
@@ -5,7 +5,7 @@ import getMockDb from "@/server/data/mock/getMockDb";
 import { tokenXFetchPost } from "@/server/tokenXFetch/tokenXFetchPost";
 import serverEnv from "@/server/utils/serverEnv";
 import { isValidUuid } from "@/server/utils/validateUuid";
-import type { SvarRespons } from "../../../../../types/shared/brev";
+import type { SvarRespons } from "@/types/shared/brev";
 
 const handler = async (
   req: NextApiRequest,

--- a/src/pages/api/arbeidsgiver/motebehov/index.api.ts
+++ b/src/pages/api/arbeidsgiver/motebehov/index.api.ts
@@ -1,16 +1,16 @@
 import { logger } from "@navikt/next-logger";
 import type { NextApiRequest, NextApiResponse } from "next";
 import { v4 as uuidv4 } from "uuid";
+import {
+  meldMotebehovAGOutputFixture,
+  svarMotebehovAGOutputFixture,
+} from "@/mocks/data/fixtures/form";
 import { MAX_LENGTH_MOTEBEHOV_SVAR_JSON } from "@/pages/api/constants";
 import { TokenXTargetApi } from "@/server/auth/tokenXExchange";
 import getMockDb from "@/server/data/mock/getMockDb";
 import { tokenXFetchPost } from "@/server/tokenXFetch/tokenXFetchPost";
 import serverEnv, { isMockBackend } from "@/server/utils/serverEnv";
 import type { MotebehovSvarRequestAG } from "@/types/shared/motebehov";
-import {
-  meldMotebehovAGOutputFixture,
-  svarMotebehovAGOutputFixture,
-} from "../../../../mocks/data/fixtures/form";
 
 const handler = async (
   req: NextApiRequest,

--- a/src/pages/api/arbeidsgiver/motebehov/index.api.ts
+++ b/src/pages/api/arbeidsgiver/motebehov/index.api.ts
@@ -1,8 +1,4 @@
 import { logger } from "@navikt/next-logger";
-import {
-  meldMotebehovAGOutputFixture,
-  svarMotebehovAGOutputFixture,
-} from "mocks/data/fixtures/form";
 import type { NextApiRequest, NextApiResponse } from "next";
 import { v4 as uuidv4 } from "uuid";
 import { MAX_LENGTH_MOTEBEHOV_SVAR_JSON } from "@/pages/api/constants";
@@ -11,6 +7,10 @@ import getMockDb from "@/server/data/mock/getMockDb";
 import { tokenXFetchPost } from "@/server/tokenXFetch/tokenXFetchPost";
 import serverEnv, { isMockBackend } from "@/server/utils/serverEnv";
 import type { MotebehovSvarRequestAG } from "@/types/shared/motebehov";
+import {
+  meldMotebehovAGOutputFixture,
+  svarMotebehovAGOutputFixture,
+} from "../../../../mocks/data/fixtures/form";
 
 const handler = async (
   req: NextApiRequest,

--- a/src/pages/api/scenario/activescenario.api.ts
+++ b/src/pages/api/scenario/activescenario.api.ts
@@ -1,11 +1,11 @@
 import type { NextApiRequest, NextApiResponse } from "next";
-import { getMockSetupForScenario } from "server/data/mock/activeMockData";
+import { TEST_SESSION_ID } from "@/common/api/fetch";
+import { isDemoOrLocal } from "@/common/publicEnv";
+import { getMockSetupForScenario } from "@/server/data/mock/activeMockData";
 import getMockDb, {
   assignNewDbSetup,
   type TestScenario,
-} from "server/data/mock/getMockDb";
-import { TEST_SESSION_ID } from "@/common/api/fetch";
-import { isDemoOrLocal } from "@/common/publicEnv";
+} from "@/server/data/mock/getMockDb";
 import { handleQueryParamError } from "@/server/utils/errors";
 
 export default function handler(req: NextApiRequest, res: NextApiResponse) {

--- a/src/pages/api/sykmeldt/brev/[uuid]/svar.api.ts
+++ b/src/pages/api/sykmeldt/brev/[uuid]/svar.api.ts
@@ -5,7 +5,7 @@ import getMockDb from "@/server/data/mock/getMockDb";
 import { tokenXFetchPost } from "@/server/tokenXFetch/tokenXFetchPost";
 import serverEnv from "@/server/utils/serverEnv";
 import { isValidUuid } from "@/server/utils/validateUuid";
-import type { SvarRespons } from "../../../../../types/shared/brev";
+import type { SvarRespons } from "@/types/shared/brev";
 
 const handler = async (
   req: NextApiRequest,

--- a/src/pages/api/sykmeldt/motebehov/index.api.ts
+++ b/src/pages/api/sykmeldt/motebehov/index.api.ts
@@ -1,16 +1,16 @@
 import { logger } from "@navikt/next-logger";
 import type { NextApiRequest, NextApiResponse } from "next";
 import { v4 as uuidv4 } from "uuid";
+import {
+  meldMotebehovSMResponseFixture,
+  svarMotebehovSMResponseFixture,
+} from "@/mocks/data/fixtures/form";
 import { MAX_LENGTH_MOTEBEHOV_SVAR_JSON } from "@/pages/api/constants";
 import { TokenXTargetApi } from "@/server/auth/tokenXExchange";
 import getMockDb from "@/server/data/mock/getMockDb";
 import { tokenXFetchPost } from "@/server/tokenXFetch/tokenXFetchPost";
 import serverEnv, { isMockBackend } from "@/server/utils/serverEnv";
 import type { MotebehovSvarRequest } from "@/types/shared/motebehov";
-import {
-  meldMotebehovSMResponseFixture,
-  svarMotebehovSMResponseFixture,
-} from "../../../../mocks/data/fixtures/form";
 
 const handler = async (
   req: NextApiRequest,

--- a/src/pages/api/sykmeldt/motebehov/index.api.ts
+++ b/src/pages/api/sykmeldt/motebehov/index.api.ts
@@ -1,8 +1,4 @@
 import { logger } from "@navikt/next-logger";
-import {
-  meldMotebehovSMResponseFixture,
-  svarMotebehovSMResponseFixture,
-} from "mocks/data/fixtures/form";
 import type { NextApiRequest, NextApiResponse } from "next";
 import { v4 as uuidv4 } from "uuid";
 import { MAX_LENGTH_MOTEBEHOV_SVAR_JSON } from "@/pages/api/constants";
@@ -11,6 +7,10 @@ import getMockDb from "@/server/data/mock/getMockDb";
 import { tokenXFetchPost } from "@/server/tokenXFetch/tokenXFetchPost";
 import serverEnv, { isMockBackend } from "@/server/utils/serverEnv";
 import type { MotebehovSvarRequest } from "@/types/shared/motebehov";
+import {
+  meldMotebehovSMResponseFixture,
+  svarMotebehovSMResponseFixture,
+} from "../../../../mocks/data/fixtures/form";
 
 const handler = async (
   req: NextApiRequest,

--- a/src/pages/arbeidsgiver/[narmestelederid]/index.page.tsx
+++ b/src/pages/arbeidsgiver/[narmestelederid]/index.page.tsx
@@ -1,7 +1,6 @@
 import { Skeleton } from "@navikt/ds-react";
 import type { UseQueryResult } from "@tanstack/react-query";
 import type { NextPage } from "next";
-import type { DialogmoteData } from "types/shared/dialogmote";
 import { useDialogmoteDataAG } from "@/common/api/queries/arbeidsgiver/dialogmoteDataQueryAG";
 import { MotebehovPanelAG } from "@/common/components/motebehov/panel/MotebehovPanelAG";
 import MoteinnkallingPanel from "@/common/components/moteinnkalling/MoteinnkallingPanel";
@@ -10,6 +9,7 @@ import PersonvernInfo from "@/common/components/personvern/PersonvernInfo";
 import InfoTilArbeidsgiver from "@/common/components/referat/InfoTilArbeidsgiver";
 import ReferaterPanel from "@/common/components/referat/ReferaterPanel";
 import VideoPanel from "@/common/components/video/VideoPanel";
+import type { DialogmoteData } from "@/types/shared/dialogmote";
 
 const texts = {
   title: "Dialogmøter",

--- a/src/pages/arbeidsgiver/[narmestelederid]/motebehov/meld.page.tsx
+++ b/src/pages/arbeidsgiver/[narmestelederid]/motebehov/meld.page.tsx
@@ -1,14 +1,14 @@
 import { BodyLong, BodyShort } from "@navikt/ds-react";
 import type { ReactElement } from "react";
-import type {
-  MotebehovSvarRequest,
-  MotebehovSvarRequestAG,
-} from "types/shared/motebehov";
 import { useDialogmoteDataAG } from "@/common/api/queries/arbeidsgiver/dialogmoteDataQueryAG";
 import { useSvarPaMotebehovAG } from "@/common/api/queries/arbeidsgiver/motebehovQueriesAG";
 import MeldBehovForm from "@/common/components/motebehov/MeldBehovForm";
 import { ArbeidsgiverMeldBehovGuidePanel } from "@/common/components/motebehov/SvarOgMeldBehovGuidePanels";
 import ArbeidsgiverSide from "@/common/components/page/ArbeidsgiverSide";
+import type {
+  MotebehovSvarRequest,
+  MotebehovSvarRequestAG,
+} from "@/types/shared/motebehov";
 import {
   arbeidsgiverLesMerLenkerSentence,
   commonTextsForAGSvarAndMeld,

--- a/src/pages/arbeidsgiver/[narmestelederid]/motebehov/meld.test.tsx
+++ b/src/pages/arbeidsgiver/[narmestelederid]/motebehov/meld.test.tsx
@@ -3,9 +3,9 @@ import { HttpResponse, http } from "msw";
 import mockRouter from "next-router-mock";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import { axe } from "vitest-axe";
+import { meldMotebehovAGFixture } from "@/mocks/data/fixtures/form";
+import { testServer } from "@/mocks/testServer";
 import MeldBehov from "@/pages/arbeidsgiver/[narmestelederid]/motebehov/meld.page";
-import { meldMotebehovAGFixture } from "../../../../mocks/data/fixtures/form";
-import { testServer } from "../../../../mocks/testServer";
 import { render, screen } from "../../../../test/testUtils";
 
 describe("meld page arbeidsgiver", () => {

--- a/src/pages/arbeidsgiver/[narmestelederid]/motebehov/svar.page.tsx
+++ b/src/pages/arbeidsgiver/[narmestelederid]/motebehov/svar.page.tsx
@@ -1,10 +1,6 @@
 import { ExternalLinkIcon } from "@navikt/aksel-icons";
 import { BodyLong, BodyShort, Link } from "@navikt/ds-react";
 import type { ReactElement } from "react";
-import type {
-  MotebehovSvarRequest,
-  MotebehovSvarRequestAG,
-} from "types/shared/motebehov";
 import { useDialogmoteDataAG } from "@/common/api/queries/arbeidsgiver/dialogmoteDataQueryAG";
 import { useSvarPaMotebehovAG } from "@/common/api/queries/arbeidsgiver/motebehovQueriesAG";
 import SvarBehovForm from "@/common/components/motebehov/SvarBehovForm";
@@ -14,6 +10,10 @@ import {
   ARBEIDSGIVER_DIALOGMOTE_MED_NAV_INFO_URL,
   ARBEIDSGIVER_VIRKEMIDLER_OG_TILTAK_INFO_URL,
 } from "@/common/constants/staticUrls";
+import type {
+  MotebehovSvarRequest,
+  MotebehovSvarRequestAG,
+} from "@/types/shared/motebehov";
 
 export const commonTextsForSvarAGAndSM = {
   topBodyText:

--- a/src/pages/arbeidsgiver/[narmestelederid]/motebehov/svar.test.tsx
+++ b/src/pages/arbeidsgiver/[narmestelederid]/motebehov/svar.test.tsx
@@ -3,10 +3,10 @@ import { HttpResponse, http } from "msw";
 import mockRouter from "next-router-mock";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import { axe } from "vitest-axe";
+import { createSvarBehovAG } from "@/mocks/data/factories/dialogmote";
+import { svarMotebehovAGFixture } from "@/mocks/data/fixtures/form";
+import { testServer } from "@/mocks/testServer";
 import SvarBehov from "@/pages/arbeidsgiver/[narmestelederid]/motebehov/svar.page";
-import { createSvarBehovAG } from "../../../../mocks/data/factories/dialogmote";
-import { svarMotebehovAGFixture } from "../../../../mocks/data/fixtures/form";
-import { testServer } from "../../../../mocks/testServer";
 import { render, screen } from "../../../../test/testUtils";
 
 describe("svar page arbeidsgiver", () => {

--- a/src/pages/sykmeldt/motebehov/meld.test.tsx
+++ b/src/pages/sykmeldt/motebehov/meld.test.tsx
@@ -3,9 +3,9 @@ import { HttpResponse, http } from "msw";
 import mockRouter from "next-router-mock";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import { axe } from "vitest-axe";
+import { meldMotebehovSMFixture } from "@/mocks/data/fixtures/form";
+import { testServer } from "@/mocks/testServer";
 import MeldBehov from "@/pages/sykmeldt/motebehov/meld.page";
-import { meldMotebehovSMFixture } from "../../../mocks/data/fixtures/form";
-import { testServer } from "../../../mocks/testServer";
 import { render, screen } from "../../../test/testUtils";
 
 describe("meld page sykmeldt", () => {

--- a/src/pages/sykmeldt/motebehov/svar.test.tsx
+++ b/src/pages/sykmeldt/motebehov/svar.test.tsx
@@ -3,10 +3,10 @@ import { HttpResponse, http } from "msw";
 import mockRouter from "next-router-mock";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import { axe } from "vitest-axe";
+import { createSvarBehovSM } from "@/mocks/data/factories/dialogmote";
+import { svarMotebehovSMFixture } from "@/mocks/data/fixtures/form";
+import { testServer } from "@/mocks/testServer";
 import SvarBehov from "@/pages/sykmeldt/motebehov/svar.page";
-import { createSvarBehovSM } from "../../../mocks/data/factories/dialogmote";
-import { svarMotebehovSMFixture } from "../../../mocks/data/fixtures/form";
-import { testServer } from "../../../mocks/testServer";
 import { render, screen } from "../../../test/testUtils";
 
 describe("svar page sykmeldt", () => {

--- a/src/server/data/arbeidsgiver/fetchConcurrentDataAG.ts
+++ b/src/server/data/arbeidsgiver/fetchConcurrentDataAG.ts
@@ -10,7 +10,7 @@ import { getMotebehovAG } from "@/server/service/motebehovService";
 import type { MotebehovStatusDTO } from "@/server/service/schema/motebehovSchema";
 import { handleSchemaParsingError } from "@/server/utils/errors";
 import { isMockBackend } from "@/server/utils/serverEnv";
-import type { Brev } from "../../../types/shared/brev";
+import type { Brev } from "@/types/shared/brev";
 
 export const fetchConcurrentDataAG = async (
   req: NextApiRequest,

--- a/src/server/data/common/mapMotebehov.ts
+++ b/src/server/data/common/mapMotebehov.ts
@@ -1,8 +1,8 @@
-import type { Motebehov, MotebehovSvar } from "types/shared/motebehov";
 import type {
   MotebehovDataDTO,
   MotebehovStatusDTO,
 } from "@/server/service/schema/motebehovSchema";
+import type { Motebehov, MotebehovSvar } from "@/types/shared/motebehov";
 
 const mapMotebehovSvar = (
   motebehovData: MotebehovDataDTO | null,

--- a/src/server/data/common/mapReferater.ts
+++ b/src/server/data/common/mapReferater.ts
@@ -1,6 +1,6 @@
-import type { Referat } from "types/shared/brev";
 import { infoUrls } from "@/common/constants/InfoUrls";
 import type { BrevDTO } from "@/server/service/schema/brevSchema";
+import type { Referat } from "@/types/shared/brev";
 
 export const mapReferater = (brev?: BrevDTO[]): Referat[] => {
   return (

--- a/src/server/data/mock/builders/brevBuilder.ts
+++ b/src/server/data/mock/builders/brevBuilder.ts
@@ -1,6 +1,6 @@
-import type { BrevType, DocumentComponent } from "types/client/brev";
-import type { Brev } from "types/shared/brev";
 import { v4 as uuidv4 } from "uuid";
+import type { BrevType, DocumentComponent } from "@/types/client/brev";
+import type { Brev } from "@/types/shared/brev";
 
 export class BrevBuilder {
   private readonly brev: Brev;

--- a/src/server/data/mock/builders/documentBuilder.ts
+++ b/src/server/data/mock/builders/documentBuilder.ts
@@ -1,4 +1,4 @@
-import type { DocumentComponent } from "types/client/brev";
+import type { DocumentComponent } from "@/types/client/brev";
 
 export class DocumentBuilder {
   private readonly document: DocumentComponent[];

--- a/src/server/data/mock/builders/documentComponentBuilder.ts
+++ b/src/server/data/mock/builders/documentComponentBuilder.ts
@@ -2,7 +2,7 @@ import type {
   DocumentComponent,
   DocumentComponentKey,
   DocumentComponentType,
-} from "types/client/brev";
+} from "@/types/client/brev";
 
 export class DocumentComponentBuilder {
   private readonly documentComponent: DocumentComponent;

--- a/src/server/data/mock/builders/testScenarioBuilder.ts
+++ b/src/server/data/mock/builders/testScenarioBuilder.ts
@@ -1,6 +1,6 @@
-import type { Brev } from "types/shared/brev";
 import type { MockSetup, TestScenario } from "@/server/data/mock/getMockDb";
 import type { MotebehovStatusDTO } from "@/server/service/schema/motebehovSchema";
+import type { Brev } from "@/types/shared/brev";
 
 export class TestScenarioBuilder {
   private readonly mockData: MockSetup;

--- a/src/server/data/mock/getMockDb.ts
+++ b/src/server/data/mock/getMockDb.ts
@@ -2,8 +2,8 @@ import type { NextApiRequest } from "next";
 import { TEST_SESSION_ID } from "@/common/api/fetch";
 import type { MotebehovStatusDTO } from "@/server/service/schema/motebehovSchema";
 import type { SykmeldtDTO } from "@/server/service/schema/sykmeldtSchema";
+import { handleQueryParamError } from "@/server/utils/errors";
 import type { Brev } from "@/types/shared/brev";
-import { handleQueryParamError } from "../../utils/errors";
 import activeMockData, { getMockSetupForScenario } from "./activeMockData";
 
 export type TestScenario =

--- a/src/server/data/mock/labs/innkalling.ts
+++ b/src/server/data/mock/labs/innkalling.ts
@@ -1,4 +1,4 @@
-import type { Brev } from "types/shared/brev";
+import type { Brev } from "@/types/shared/brev";
 
 export const innkallingSM: Brev = {
   uuid: "2fb875a2-325e-4f91-bb53-36592efe30d5",

--- a/src/server/data/mock/labs/referat.ts
+++ b/src/server/data/mock/labs/referat.ts
@@ -1,4 +1,4 @@
-import type { Brev } from "types/shared/brev";
+import type { Brev } from "@/types/shared/brev";
 
 export const referat1: Brev = {
   uuid: "0eda3772-1cab-482e-be5f-c18387cd8709",

--- a/src/server/data/sykmeldt/__tests__/mapDialogmoteDataSM.test.ts
+++ b/src/server/data/sykmeldt/__tests__/mapDialogmoteDataSM.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from "vitest";
+import { createBrevDTO } from "@/mocks/data/factories/brevDTO";
 import { mapDialogmoteDataSM } from "@/server/data/sykmeldt/mapDialogmoteDataSM";
-import { createBrevDTO } from "../../../../mocks/data/factories/brevDTO";
 
 describe("mapDialogmoteDataSM", () => {
   describe("moteinnkalling", () => {

--- a/src/server/data/sykmeldt/fetchConcurrentDataSM.ts
+++ b/src/server/data/sykmeldt/fetchConcurrentDataSM.ts
@@ -9,7 +9,7 @@ import { getMotebehovSM } from "@/server/service/motebehovService";
 import type { MotebehovStatusDTO } from "@/server/service/schema/motebehovSchema";
 import { handleSchemaParsingError } from "@/server/utils/errors";
 import { isMockBackend } from "@/server/utils/serverEnv";
-import type { Brev } from "../../../types/shared/brev";
+import type { Brev } from "@/types/shared/brev";
 
 export const fetchConcurrentDataSM = async (
   req: NextApiRequest,

--- a/src/server/data/types/next/NextApiResponseAG.ts
+++ b/src/server/data/types/next/NextApiResponseAG.ts
@@ -1,8 +1,8 @@
 import type { NextApiResponse } from "next";
-import type { DialogmoteData } from "types/shared/dialogmote";
 import type { BrevDTO } from "@/server/service/schema/brevSchema";
 import type { MotebehovStatusDTO } from "@/server/service/schema/motebehovSchema";
 import type { SykmeldtDTO } from "@/server/service/schema/sykmeldtSchema";
+import type { DialogmoteData } from "@/types/shared/dialogmote";
 
 export interface NextApiResponseAG extends NextApiResponse {
   sykmeldt: SykmeldtDTO;

--- a/src/server/data/types/next/NextApiResponseSM.ts
+++ b/src/server/data/types/next/NextApiResponseSM.ts
@@ -1,7 +1,7 @@
 import type { NextApiResponse } from "next";
-import type { DialogmoteData } from "types/shared/dialogmote";
 import type { BrevDTO } from "@/server/service/schema/brevSchema";
 import type { MotebehovStatusDTO } from "@/server/service/schema/motebehovSchema";
+import type { DialogmoteData } from "@/types/shared/dialogmote";
 
 export interface NextApiResponseSM extends NextApiResponse {
   motebehov: MotebehovStatusDTO;

--- a/src/server/service/brevService.ts
+++ b/src/server/service/brevService.ts
@@ -1,6 +1,6 @@
 import { array } from "zod";
 import { get } from "@/common/api/fetch";
-import serverEnv from "../utils/serverEnv";
+import serverEnv from "@/server/utils/serverEnv";
 import { brevSchema } from "./schema/brevSchema";
 
 export async function getBrevAG(accessToken: string, personIdent: string) {

--- a/src/test/vitest.setup.mts
+++ b/src/test/vitest.setup.mts
@@ -7,7 +7,7 @@ import { cleanup } from "@testing-library/react";
 import { afterAll, afterEach, beforeAll, expect, vi } from "vitest";
 import * as vitestAxeMatchers from "vitest-axe/matchers";
 
-import { testServer } from "../mocks/testServer";
+import { testServer } from "@/mocks/testServer";
 
 expect.extend(matchers);
 expect.extend(vitestAxeMatchers);

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -9,20 +9,19 @@
     "noEmit": true,
     "esModuleInterop": true,
     "module": "esnext",
-    "moduleResolution": "node",
+    "moduleResolution": "bundler",
     "resolveJsonModule": true,
     "isolatedModules": true,
     "jsx": "react-jsx",
     "incremental": true,
-    "baseUrl": "./src",
     "types": ["@testing-library/jest-dom", "react", "react-dom"],
     "paths": {
-      "@/common/*": ["common/*"],
-      "@/server/*": ["server/*"],
-      "@/pages/*": ["pages/*"],
-      "@/context/*": ["context/*"],
-      "@/fixtures/*": ["fixtures/*"],
-      "@/types/*": ["types/*"]
+      "@/common/*": ["./src/common/*"],
+      "@/server/*": ["./src/server/*"],
+      "@/pages/*": ["./src/pages/*"],
+      "@/context/*": ["./src/context/*"],
+      "@/fixtures/*": ["./src/fixtures/*"],
+      "@/types/*": ["./src/types/*"]
     }
   },
   "include": ["next-env.d.ts", "**/*.ts", "**/*.tsx", "setup.d.ts"],

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -21,6 +21,7 @@
       "@/pages/*": ["./src/pages/*"],
       "@/context/*": ["./src/context/*"],
       "@/fixtures/*": ["./src/fixtures/*"],
+      "@/mocks/*": ["./src/mocks/*"],
       "@/types/*": ["./src/types/*"]
     }
   },


### PR DESCRIPTION
## Beskrivelse

Rydder opp importstier slik at interne imports bruker det eksplisitte `@/`-aliaset, og justerer `tsconfig.json` slik at aliasene peker direkte mot `src`.

## Endringer

- `tsconfig.json`: fjernet `baseUrl`, satt `moduleResolution` til `bundler` og gjorde path-aliasene eksplisitte mot `./src/...`
- `src/**`: oppdatert interne imports fra `types/...`, `server/...` og relative paths til `@/...` der relevant

## Issue

Ingen issue koblet.

## Sjekkliste

- [x] Koden kompilerer og linter uten feil
- [x] Endringene er testet (manuelt eller automatisk)
- [x] Ingen sensitiv data eksponert (tokens, credentials, PII)

## Verifisert

- `pnpm run build`
- `pnpm run lint`
- `pnpm exec vitest run`
- `git diff --check`