### PR TITLE
refactor(config): fjern ubrukt oppfølgingsplanvariabel

### DIFF
--- a/.env
+++ b/.env
@@ -1,5 +1,4 @@
 NEXT_PUBLIC_BASEPATH=/syk/dialogmoter
 NEXT_PUBLIC_MIN_SIDE_ROOT=https://www.nav.no/minside/
-NEXT_PUBLIC_OPPFOLGINGSPLAN_PATH_SM=/syk/oppfolgingsplaner/sykmeldt
 NEXT_PUBLIC_NY_OPPFOLGINGSPLAN_ROOT=https://www.nav.no/syk/oppfolgingsplan
 UNLEASH_API_URL=https://unleash.nais.io/api/client/features?tag[]=simple:dialogmote

--- a/src/common/publicEnv.ts
+++ b/src/common/publicEnv.ts
@@ -12,8 +12,6 @@ export const cdnPublicPath: string | undefined = process.env
   : (process.env.NEXT_PUBLIC_BASEPATH ?? "");
 
 export const minSideRoot = process.env.NEXT_PUBLIC_MIN_SIDE_ROOT as string;
-export const oppfolgingsplanUrlSM: string = process.env
-  .NEXT_PUBLIC_OPPFOLGINGSPLAN_PATH_SM as string;
 export const nyOppfolgingsplanRoot: string = process.env
   .NEXT_PUBLIC_NY_OPPFOLGINGSPLAN_ROOT as string;
 


### PR DESCRIPTION
## Beskrivelse

Fjerner en ubrukt offentlig miljøvariabel for den gamle oppfølgingsplanstien og den tilhørende eksporten. Dette er en avgrenset dødkodeopprydding uten UI-endringer.

## Endringer

- `.env`: Fjernet `NEXT_PUBLIC_OPPFOLGINGSPLAN_PATH_SM`.
- `src/common/publicEnv.ts`: Fjernet den ubrukte `oppfolgingsplanUrlSM`-eksporten.

## Issue

Closes #1893

Del av epic: navikt/syfo-oppfolgingsplan-backend#386

## Verifisering

- `pnpm run lint` — vellykket
- `pnpm exec vitest run` — vellykket (12 filer / 62 tester)
- `pnpm run build` — vellykket
- Kryssmodellinspeksjon med Claude Opus 5 — ingen merknader (`😊 leveranseklart`)

## Sjekkliste

- [x] Koden kompilerer og linter uten feil
- [x] Endringene er testet (automatisk)
- [x] Ingen sensitiv data eksponert (tokens, credentials, PII)